### PR TITLE
feature/friend-code

### DIFF
--- a/src/commands/public/getFriendCode.ts
+++ b/src/commands/public/getFriendCode.ts
@@ -1,0 +1,72 @@
+/* eslint-disable camelcase */
+import { GuildMember } from 'discord.js';
+import { CommandoClient, CommandoMessage } from 'discord.js-commando';
+import { stripIndents } from 'common-tags';
+
+import KirbotCommand from '../../helpers/KirbotCommand';
+import { CMD_GROUPS, CMD_NAMES, SETTINGS } from '../../helpers/constants';
+import { logger, getLogTag } from '../../helpers/logger';
+import logCommandStart from '../../helpers/logCommandStart';
+
+interface CommandArgs {
+  member: GuildMember;
+}
+
+export default class SetFriendCodeCommand extends KirbotCommand {
+  constructor (client: CommandoClient) {
+    super(client, {
+      name: CMD_NAMES.PUBLIC_GET_FRIEND_CODE,
+      group: CMD_GROUPS.PUBLIC,
+      memberName: 'friend_code_get',
+      description: 'Get your or someone else\'s Nintendo Switch friend code',
+      details: stripIndents`
+        Look up each other's friend codes!
+      `,
+      guildOnly: true,
+      examples: [
+        `${CMD_NAMES.PUBLIC_GET_FRIEND_CODE}`,
+        `${CMD_NAMES.PUBLIC_GET_FRIEND_CODE} @IAmKale`,
+      ],
+      args: [
+        {
+          key: 'member',
+          type: 'member',
+          prompt: 'whose friend code are you interested in?',
+          default: (message: CommandoMessage) => message.member,
+        },
+      ],
+    });
+  }
+
+  async run (message: CommandoMessage, { member: fcMember }: CommandArgs) {
+    const { id, member } = message;
+
+    const tag = getLogTag(id);
+
+    logCommandStart(tag, message);
+
+    let currentCodes = this.client.settings.get(SETTINGS.FRIEND_CODES);
+    if (!currentCodes) {
+      currentCodes = {};
+    }
+
+    logger.info(tag, `Retrieving friend code for ${fcMember.user.tag} (${fcMember.id})`);
+
+    const code = currentCodes[fcMember.id];
+
+    let msgWho;
+    if (fcMember === member) {
+      msgWho = 'your';
+    } else {
+      msgWho = `${fcMember}'s`;
+    }
+
+    if (!code) {
+      logger.info(tag, 'Could not find a friend code');
+      return message.reply(`I couldn't find ${msgWho} friend code...`);
+    }
+
+    logger.debug(tag, `Replying with friend code: ${code}`);
+    return message.reply(`${msgWho} friend code is **${code}**`);
+  }
+}

--- a/src/commands/public/setFriendCode.ts
+++ b/src/commands/public/setFriendCode.ts
@@ -1,0 +1,86 @@
+/* eslint-disable camelcase */
+import { GuildMember } from 'discord.js';
+import { CommandoClient, CommandoMessage } from 'discord.js-commando';
+import { oneLine, stripIndents } from 'common-tags';
+
+import KirbotCommand from '../../helpers/KirbotCommand';
+import { CMD_GROUPS, CMD_NAMES, SETTINGS } from '../../helpers/constants';
+import { logger, getLogTag } from '../../helpers/logger';
+import logCommandStart from '../../helpers/logCommandStart';
+
+interface RoleArgs {
+  code: string | GuildMember;
+}
+
+// Expect a value like this: SW-1234-5678-9012
+const regexFriendCode = /^sw-[\d]{4}-[\d]{4}-[\d]{4}$/i;
+
+export default class SetFriendCodeCommand extends KirbotCommand {
+  constructor (client: CommandoClient) {
+    super(client, {
+      name: CMD_NAMES.PUBLIC_SET_FRIEND_CODE,
+      group: CMD_GROUPS.PUBLIC,
+      memberName: 'friend_code',
+      description: 'Register your Nintendo Switch friend code',
+      details: stripIndents`
+        Register your friend code so that others can easily add you!
+      `,
+      guildOnly: true,
+      examples: [
+        `${CMD_NAMES.PUBLIC_SET_FRIEND_CODE} SW-1234-5678-9012`,
+      ],
+      args: [
+        {
+          key: 'code',
+          type: 'string',
+          prompt: 'what is your Nintendo Switch friend code?',
+          validate: (code: string, message: CommandoMessage): boolean | string => {
+            const { id } = message;
+            const tag = getLogTag(id);
+
+            logCommandStart(tag, message);
+
+            // User is registering a friend code for their self
+            logger.info(tag, `Validating friend code "${code}"`);
+
+            // Make sure the friend code is correctly formatted
+            const matched = regexFriendCode.test(code);
+
+            if (!matched) {
+              return oneLine`
+                that doesn't appear to be a valid friend code. Try again (hint: are you missing
+                "SW-" at the beginning?)
+              `;
+            }
+
+            logger.info(tag, 'Friend code matches expected format');
+
+            return true;
+          },
+        },
+      ],
+    });
+  }
+
+  async run (message: CommandoMessage, { code }: RoleArgs) {
+    const { id, member } = message;
+
+    const tag = getLogTag(id);
+
+    logger.info(
+      tag,
+      `Registering friend code "${code}" for ${member.user.tag} (${member.id})`,
+    );
+
+    let currentCodes = this.client.settings.get(SETTINGS.FRIEND_CODES);
+    if (!currentCodes) {
+      currentCodes = {};
+    }
+
+    currentCodes[member.id] = code;
+
+    this.client.settings.set(SETTINGS.FRIEND_CODES, currentCodes);
+
+    return message.reply(`your friend code is now ${code}`);
+  }
+}

--- a/src/commands/public/setFriendCode.ts
+++ b/src/commands/public/setFriendCode.ts
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import { GuildMember } from 'discord.js';
 import { CommandoClient, CommandoMessage } from 'discord.js-commando';
 import { oneLine, stripIndents } from 'common-tags';
 
@@ -8,8 +7,8 @@ import { CMD_GROUPS, CMD_NAMES, SETTINGS } from '../../helpers/constants';
 import { logger, getLogTag } from '../../helpers/logger';
 import logCommandStart from '../../helpers/logCommandStart';
 
-interface RoleArgs {
-  code: string | GuildMember;
+interface CommandArgs {
+  code: string;
 }
 
 // Expect a value like this: SW-1234-5678-9012
@@ -20,7 +19,7 @@ export default class SetFriendCodeCommand extends KirbotCommand {
     super(client, {
       name: CMD_NAMES.PUBLIC_SET_FRIEND_CODE,
       group: CMD_GROUPS.PUBLIC,
-      memberName: 'friend_code',
+      memberName: 'friend_code_set',
       description: 'Register your Nintendo Switch friend code',
       details: stripIndents`
         Register your friend code so that others can easily add you!
@@ -62,7 +61,7 @@ export default class SetFriendCodeCommand extends KirbotCommand {
     });
   }
 
-  async run (message: CommandoMessage, { code }: RoleArgs) {
+  async run (message: CommandoMessage, { code }: CommandArgs) {
     const { id, member } = message;
 
     const tag = getLogTag(id);

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -12,6 +12,7 @@ export enum CMD_GROUPS {
 export enum CMD_NAMES {
   PUBLIC_TOGGLE_ROLE = 'toggle-role',
   PUBLIC_SET_FRIEND_CODE = 'set-fc',
+  PUBLIC_GET_FRIEND_CODE = 'fc',
 }
 
 export enum SETTINGS {

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -11,6 +11,11 @@ export enum CMD_GROUPS {
 
 export enum CMD_NAMES {
   PUBLIC_TOGGLE_ROLE = 'toggle-role',
+  PUBLIC_SET_FRIEND_CODE = 'set-fc',
+}
+
+export enum SETTINGS {
+  FRIEND_CODES = 'friendCodes',
 }
 
 /**


### PR DESCRIPTION
Adds two new commands:

- `<set-fc`: Register your Switch friend code
- `<fc`: Retrieve your or someone else's friend code