### PR TITLE
feat/command-vouch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - DISCORD_BOT_TOKEN
       - DISCORD_BOT_APPLICATION_ID
       - DISCORD_BOT_GUILD_ID
+      - DISCORD_GUILD_VOUCH_ROLE_ID
       - PAPERTRAIL_HOST
       - PAPERTRAIL_PORT
     command: "npm run host"

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -15,6 +15,7 @@ export const {
   DISCORD_BOT_TOKEN,
   DISCORD_BOT_APPLICATION_ID,
   DISCORD_BOT_GUILD_ID,
+  DISCORD_GUILD_VOUCH_ROLE_ID, // Miis role in Nintengoons
   PAPERTRAIL_HOST,
   PAPERTRAIL_PORT,
 } = process.env;
@@ -23,7 +24,7 @@ export enum CMD_GROUPS {
   PUBLIC = 'public',
 }
 
-export const kirbotCommandNames = ['toggle-role', 'friend-code'] as const;
+export const kirbotCommandNames = ['toggle-role', 'friend-code', 'vouch'] as const;
 export type KirbotCommandName = typeof kirbotCommandNames[number];
 
 export type KirbotCommandConfig =

--- a/src/slashCommands/friendCode.ts
+++ b/src/slashCommands/friendCode.ts
@@ -39,11 +39,11 @@ const regexFriendCode = /^(?:sw[- ])?([\d]{4}[- ][\d]{4}[- ][\d]{4})$/i;
  */
 export const config = new SlashCommandBuilder()
   .setName('friend-code' as KirbotCommandName)
-  .setDescription('Switch Friend Codes Lookup')
+  .setDescription('Look up Switch friend codes')
   .addSubcommand(subcommand =>
     subcommand
       .setName(SubCommand.Get)
-      .setDescription('Look up your or someone else\'s Switch friend code')
+      .setDescription('Get your or someone else\'s Switch friend code')
       .addUserOption(option =>
         option
           .setName(Options.Friend)

--- a/src/slashCommands/vouch.ts
+++ b/src/slashCommands/vouch.ts
@@ -55,9 +55,17 @@ export const handler: KirbotCommandHandler = async (interaction) => {
     throw new Error(`User ID ${friendUser.id} does not exist in this guild`);
   }
 
-  const roleManager = friendMember.roles as GuildMemberRoleManager;
+  const invokerRoleManager = invoker.roles as GuildMemberRoleManager;
 
-  if (roleManager.cache.has(vouchRole.id)) {
+  // Require the caller of the command to have the vouch role, otherwise new members can vouch for
+  // new members
+  if (!invokerRoleManager.cache.has(vouchRole.id)) {
+    return interaction.reply(`Hey, get someone to vouch for you first! ${emojiKirybgun}`);
+  }
+
+  const friendRoleManager = friendMember.roles as GuildMemberRoleManager;
+
+  if (friendRoleManager.cache.has(vouchRole.id)) {
     return interaction.reply(`That user already has access to the server! ${emojiKirybgun}`);
   }
 
@@ -65,7 +73,7 @@ export const handler: KirbotCommandHandler = async (interaction) => {
   const invokerTag = getMemberTag(invoker);
   const friendMemberTag = getMemberTag(friendMember);
   logger.info(tag, `New member ${friendMemberTag} has been vouched for, adding role`);
-  roleManager.add(
+  friendRoleManager.add(
     vouchRole,
     `${invokerTag} successfully vouched for ${friendMemberTag}`,
   );

--- a/src/slashCommands/vouch.ts
+++ b/src/slashCommands/vouch.ts
@@ -1,0 +1,74 @@
+import { GuildMemberRoleManager, SlashCommandBuilder, User } from 'discord.js';
+
+import { logCommandStart } from '../helpers/logCommandStart';
+import { logger } from '../helpers/logger';
+import { getMemberTag } from '../helpers/getMemberTag';
+import {
+  KirbotCommandHandler,
+  KirbotCommandName,
+  DISCORD_GUILD_VOUCH_ROLE_ID,
+} from '../helpers/constants';
+
+enum Options {
+  Friend = 'friend',
+}
+
+const emojiKirbot = '<:kirbot:363386626837315584>';
+const emojiKirybgun = '<:kirbygun:641427030004596756>';
+
+export const config = new SlashCommandBuilder()
+  .setName('vouch' as KirbotCommandName)
+  .setDescription('Help your friends get access to the rest of the server')
+  .addUserOption(option =>
+    option
+      .setName(Options.Friend)
+      .setDescription('Who do you want to vouch for?')
+      .setRequired(true),
+  );
+
+export const handler: KirbotCommandHandler = async (interaction) => {
+  const { options, member: invoker, guild } = interaction;
+
+  const tag = logCommandStart(interaction);
+
+  if (!invoker) {
+    logger.error(tag, 'How did this command get invoked by a non-member?');
+    throw new Error('How did this command get invoked by a non-member?');
+  }
+
+  if (!DISCORD_GUILD_VOUCH_ROLE_ID) {
+    logger.error(tag, 'No vouch role ID set for this guild');
+    throw new Error('No vouch role ID set for this guild');
+  }
+
+  const friendUser = options.getUser(Options.Friend, true) as User;
+  const friendMember = guild?.members.resolve(friendUser.id);
+  const vouchRole = guild?.roles.resolve(DISCORD_GUILD_VOUCH_ROLE_ID);
+
+  if (!vouchRole) {
+    logger.error(tag, `Vouch role ID ${DISCORD_GUILD_VOUCH_ROLE_ID} does not exist in this guild`);
+    throw new Error(`Vouch role ID ${DISCORD_GUILD_VOUCH_ROLE_ID} does not exist in this guild`);
+  }
+
+  if (!friendMember) {
+    logger.error(tag, `User ID ${friendUser.id} does not exist in this guild`);
+    throw new Error(`User ID ${friendUser.id} does not exist in this guild`);
+  }
+
+  const roleManager = friendMember.roles as GuildMemberRoleManager;
+
+  if (roleManager.cache.has(vouchRole.id)) {
+    return interaction.reply(`That user already has access to the server! ${emojiKirybgun}`);
+  }
+
+  // The indicated member does not already have the specified role
+  const invokerTag = getMemberTag(invoker);
+  const friendMemberTag = getMemberTag(friendMember);
+  logger.info(tag, `New member ${friendMemberTag} has been vouched for, adding role`);
+  roleManager.add(
+    vouchRole,
+    `${invokerTag} successfully vouched for ${friendMemberTag}`,
+  );
+
+  return interaction.reply(`Welcome aboard, ${friendMember}! ${emojiKirbot}`);
+};


### PR DESCRIPTION
This PR adds a new `/vouch` slash command that members of the server can use to help new members get access to the rest of the server. Upon successful invocation the specified user is given the "vouched" role for the specific server. In the case of Nintengoons this is the **Miis** role.